### PR TITLE
Import facades directly instead of importing the aliases

### DIFF
--- a/src/Console/Commands/MigrateEncryptionCommand.php
+++ b/src/Console/Commands/MigrateEncryptionCommand.php
@@ -11,11 +11,11 @@ namespace AustinHeap\Database\Encryption\Console\Commands;
 
 use Exception;
 use RuntimeException;
-use DatabaseEncryption;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Facades\Config;
+use AustinHeap\Database\Encryption\EncryptionFacade as DatabaseEncryption;
 
 /**
  * Class MigrateEncryptionCommand.

--- a/src/EncryptionHelper.php
+++ b/src/EncryptionHelper.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace AustinHeap\Database\Encryption;
 
-use Config;
 use RuntimeException;
+use Illuminate\Support\Facades\Config;
 
 /**
  * EncryptionHelper.

--- a/src/Traits/HasEncryptedAttributes.php
+++ b/src/Traits/HasEncryptedAttributes.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 namespace AustinHeap\Database\Encryption\Traits;
 
-use Log;
-use Crypt;
-use DatabaseEncryption;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\EncryptException;
+use AustinHeap\Database\Encryption\EncryptionFacade as DatabaseEncryption;
 
 /**
  * HasEncryptedAttributes.


### PR DESCRIPTION
Updated to import the facades directly instead of importing the aliases. 

Allows package to be used without having to include the alias. Also prevents package from breaking if Laravel specific aliases (Log, Cache, Config, etc...) have been removed from `config/app.php`.