### PR TITLE
Updates Laravel to include 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     },
     "require": {
         "php": ">=7.1.0",
-        "laravel/framework": "5.5.*|5.6.*|5.7.*",
+        "laravel/framework": "5.5.*|5.6.*|5.7.*|5.8.*",
         "paragonie/random_compat": "^2.0"
     },
     "require-dev": {

--- a/tests/DatabaseTestCase.php
+++ b/tests/DatabaseTestCase.php
@@ -22,7 +22,7 @@ class DatabaseTestCase extends TestCase
 
     private $last_random_strings = null;
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->tearDownDatabase();
         parent::tearDown();


### PR DESCRIPTION
So far all I've done is add 5.8.* to composer and that required an update to `DatabaseTestCase` to align with the `protected` and return type declaration of the `tearDown` method in TestBench.